### PR TITLE
Allow specifying "global-overview" as default map

### DIFF
--- a/application/controllers/ShowController.php
+++ b/application/controllers/ShowController.php
@@ -73,6 +73,11 @@ class ShowController extends Controller
         $url = $baseurl . '/frontend/nagvis-js/index.php';
         $url .= '?mod=Map&act=view&show=' . urlencode($map);
 
+        if($map == 'global-overview') {
+            $url = $baseurl . '/frontend/nagvis-js/index.php';
+            $url .= '?mod=Overview';
+        }
+
         if ($this->params->get('showMenu')) {
             $url .= '&header_menu=1';
         } else {

--- a/application/controllers/ShowController.php
+++ b/application/controllers/ShowController.php
@@ -69,13 +69,12 @@ class ShowController extends Controller
         }
 
         $baseurl = $this->Config()->get('global', 'baseurl', '/nagvis');
-
         $url = $baseurl . '/frontend/nagvis-js/index.php';
-        $url .= '?mod=Map&act=view&show=' . urlencode($map);
 
-        if($map == 'global-overview') {
-            $url = $baseurl . '/frontend/nagvis-js/index.php';
+        if ($map === 'global-overview') {
             $url .= '?mod=Overview';
+        } else {
+            $url .= '?mod=Map&act=view&show=' . urlencode($map);
         }
 
         if ($this->params->get('showMenu')) {

--- a/doc/90-FAQ.md
+++ b/doc/90-FAQ.md
@@ -8,3 +8,8 @@ in the `nagvis.ini.php` configuration file.
 ## Map Path demo-overview.cfg doesn't exist
 
 Specify a different `default-map` in the `nagvis.ini.php` configuration file.
+
+## Use the map overview provided by NagVis
+
+You can set `default-map` to `global-overview` to use the built-in overview page from NagVis.
+This automatically only shows maps the user has access to.


### PR DESCRIPTION
I implemented a quick way to allow the use of "global-overview" as the default map.
While mod=Overview does not respect header_menu=0 it is still nice to have a simple way to include the NagVis default overview.