### PR TITLE
Add missing permission for Nagvis 1.9.48

### DIFF
--- a/library/nagvis-includes/CoreAuthorisationModIcingaweb2.php
+++ b/library/nagvis-includes/CoreAuthorisationModIcingaweb2.php
@@ -61,6 +61,7 @@ class CoreAuthorisationModIcingaweb2 extends CoreAuthorisationModule
             $perms['Map']['add']    = array('*' => true);
             $perms['Map']['edit']   = array('*' => true);
             $perms['Map']['manage'] = array('*' => true);
+            $perms['Map']['editHtml'] = array('*' => true);
         }
 
         if ($this->auth->hasPermission('nagvis/admin')) {


### PR DESCRIPTION
In Nagvis 1.9.48 an additional permission was introduced in response to a CVE.
This patch adds this new permission structure to
icingaweb2-module-nagvis.

The fix itself was thought up by @mdetrano (account on Github).

Fixes #66 