### PR TITLE
Support php 85

### DIFF
--- a/library/nagvis-includes/CoreAuthModIcingaweb2.php
+++ b/library/nagvis-includes/CoreAuthModIcingaweb2.php
@@ -40,7 +40,6 @@ class CoreAuthModIcingaweb2 extends CoreAuthModule
         $old_id = session_id();
         $cacheLimiter = ini_get('session.cache_limiter');
         ini_set('session.use_cookies', false);
-        ini_set('session.use_only_cookies', false);
         ini_set('session.cache_limiter', null);
         ini_set('session.cookie_path', '/');
         $icookie = 'Icingaweb2';
@@ -57,7 +56,6 @@ class CoreAuthModIcingaweb2 extends CoreAuthModule
         session_id($old_id);
         session_name($oldname);
         ini_set('session.use_cookies', true);
-        ini_set('session.use_only_cookies', true);
         ini_set('session.cache_limiter', $cacheLimiter);
     }
 

--- a/library/nagvis-includes/GlobalBackendicingadb.php
+++ b/library/nagvis-includes/GlobalBackendicingadb.php
@@ -611,7 +611,7 @@ class GlobalBackendicingadb implements GlobalBackendInterface
         return $results;
     }
 
-    private function getTimestamp(DateTime $time = null): ?int
+    private function getTimestamp(?DateTime $time = null): ?int
     {
         return ! $time ? null : $time->getTimestamp();
     }


### PR DESCRIPTION
Changes made:
Implicitly nullable parameters are deprecated since PHP8.4, so their types are explicitly widened to accept `null`.

Changing the ini setting `session.use_only_cookies` is deprecated since PHP8.4, so a change of this setting is removed.
Previously this setting was briefly set to `false` and then back to the default value `true`, no session is started in the meantime, so the code appears to be superfluous and the authentication works fine without it.

For PHP8.5 compatibility no other changes are necessary.

resolves: #67 