### PR TITLE
Ensure forward compatibility with `ipl-orm` by adding return types

### DIFF
--- a/library/Nagvis/Model/HostgroupSummary.php
+++ b/library/Nagvis/Model/HostgroupSummary.php
@@ -89,7 +89,7 @@ class HostgroupSummary extends BaseHostgroupSummary
         ];
     }
 
-    public function getUnions()
+    public function getUnions(): array
     {
         $unions = parent::getUnions();
         $unions[0][2] = array_merge(

--- a/library/Nagvis/Model/ServicegroupSummary.php
+++ b/library/Nagvis/Model/ServicegroupSummary.php
@@ -51,7 +51,7 @@ class ServicegroupSummary extends BaseServicegroupSummary
         ];
     }
 
-    public function getUnions()
+    public function getUnions(): array
     {
         $unions = parent::getUnions();
         $unions[0][2] = array_merge(


### PR DESCRIPTION
Introduce explicit return types in subclasses of `UnionModel` to prepare for
strict typing in `ipl-orm`. These additions are safe, as they only define return
signatures where none existed before.

refs Icinga/ipl-orm#158